### PR TITLE
add no_cache to docker image builds

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -36,6 +36,7 @@ resource "docker_image" "lambda-image" {
     context = "../lambda"
     tag = ["${aws_ecr_repository.fsxnragvector.repository_url}:latest"]
     platform = "linux/amd64"
+    no_cache = true
   }
 }
 
@@ -47,6 +48,7 @@ resource "docker_image" "embed-image" {
     context = "../embed"
     tag = ["${aws_ecr_repository.fsxnragembed.repository_url}:latest"]
     platform = "linux/amd64"
+    no_cache = true
   }
 }
 
@@ -57,6 +59,7 @@ resource "docker_image" "chat-image" {
     context = "../chatapp"
     tag = ["${aws_ecr_repository.fsxnragchat.repository_url}:latest"]
     platform = "linux/amd64"
+    no_cache = true
   }
 }
 # push image to ecr repo


### PR DESCRIPTION
*Issue #, if available:*
Issue with docker image builds in some cases. 

*Description of changes:*
added no_cache = true to terraform docker_image resources 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
